### PR TITLE
Cleaned up the spawn manager

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657934, g: 0.4964136, b: 0.5748189, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641275, b: 0.5748172, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -242,7 +242,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d1de837e00a5f48218483f0ca74dc09c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _enemy1: {fileID: 4590086578092343861, guid: 384b282a7eed9447bb28358df1be4f47, type: 3}
+  _enemyPrefab: {fileID: 4590086578092343861, guid: 384b282a7eed9447bb28358df1be4f47,
+    type: 3}
+  _enemyContainer: {fileID: 839137364}
 --- !u!4 &113864090
 Transform:
   m_ObjectHideFlags: 0
@@ -253,9 +255,40 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 839137365}
   m_Father: {fileID: 0}
   m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &839137364
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 839137365}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &839137365
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 839137364}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 113864090}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1385678723
 GameObject:

--- a/Assets/Scripts/SpawnManager.cs
+++ b/Assets/Scripts/SpawnManager.cs
@@ -5,37 +5,29 @@ using UnityEngine;
 public class SpawnManager : MonoBehaviour
 {
     [SerializeField]
-    private GameObject _enemy1;
+    private GameObject _enemyPrefab;
 
-    // Start is called before the first frame update
+    [SerializeField]
+    private GameObject _enemyContainer;
+
     void Start()
     {
-        
         StartCoroutine(SpawnRoutine());
-
     }
 
-    // Update is called once per frame
     void Update()
     {
-    }
 
-    // spawn game objects every 5 seconds
-    // Create a coroutine of type IEnumerator -- Yield Events
-    // use a While loop
+    }
 
     IEnumerator SpawnRoutine()
     {
-        // while loop (infinite loop)
-        // instantiate enemy prefab
-        // yield wait for 5 seconds
-
         while (true)
         {
-            transform.position = new Vector3(-5, 0, 0);
-            Instantiate(_enemy1, transform.position, Quaternion.identity);
+            Vector3 pxToSpawn = new Vector3(Random.Range(-8f, 8f), 7, 0);
+            GameObject newEnemy = Instantiate(_enemyPrefab, pxToSpawn, Quaternion.identity);
+            newEnemy.transform.parent = _enemyContainer.transform;
             yield return new WaitForSeconds(5.0f);
         }
     }
-
 }


### PR DESCRIPTION
Added the Enemy Container as a child to the Spawn Manager.  This is where all enemy game objects, when spawned, will be kept.  The result is that it keeps the hierarchy clean and tidy by removing the clutter.