### PR TITLE
Ammo Count update

### DIFF
--- a/Assets/Scripts/PlayerScript.cs
+++ b/Assets/Scripts/PlayerScript.cs
@@ -15,6 +15,7 @@ public class PlayerScript : MonoBehaviour
 
     [SerializeField] private int _lives = 3;
     [SerializeField] private int _score;
+    [SerializeField] private int _ammoCount =15;
 
     [SerializeField] private AudioClip _powerupAudioClip;
     [SerializeField] private AudioClip _playerLaserShotAudioClip;
@@ -106,6 +107,17 @@ public class PlayerScript : MonoBehaviour
 
     void PlayerFireLaser()
     {
+        if (_ammoCount <= 0)
+        {
+            _ammoCount = 0;
+            return;
+        }
+        else
+        {
+            _ammoCount--;
+            _uiManager.UpdateAmmoCount(_ammoCount);
+        }
+
         if (_isPlayerTripleShotActive == true)
         {
             float angleStep = _spreadAngle / _numberOfProjectiles;
@@ -127,7 +139,6 @@ public class PlayerScript : MonoBehaviour
         StartCoroutine(PlayerLaserCoolDownTimer());
 
         PlayClip(_playerLaserShotAudioClip);
-        
     }
 
     public void PlayClip(AudioClip soundEffectClip)

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -18,6 +18,7 @@ public class UIManager : MonoBehaviour
 
     [Header("UI Text Fields")]
     [SerializeField] private TMP_Text _scoreText;
+    [SerializeField] private TMP_Text _ammoCountText;
     [SerializeField] private TMP_Text _readyText;
     [SerializeField] private TMP_Text _setText;
     [SerializeField] private TMP_Text _defendText;
@@ -73,6 +74,20 @@ public class UIManager : MonoBehaviour
     public void UpdateScore(int playerScore)
     {
         _scoreText.text = "SCORE: " + playerScore.ToString();
+    }
+
+    public void UpdateAmmoCount(int ammoCount)
+    {
+        _ammoCountText.text = "AMMO: " + ammoCount.ToString();
+
+        if (ammoCount <= 15 && ammoCount > 5)
+        {
+            _ammoCountText.color = Color.yellow;
+        }
+        else if (ammoCount <= 5)
+        {
+            _ammoCountText.color = Color.red;
+        }
     }
 
     public void UpdateLives(int currentLives)


### PR DESCRIPTION
implemented ammo count to the PlayerScript.  Default start in 25, reduces by 1 every time a shot is fired. Added UI elements to the canvas showing the ammo count, changing the color of the text from green to yellow to red as the ammo count becomes critical.  Once ammo count reaches zero, Player can no longer fire.

Next step is to implement a PowerUp to replenish ammo.