### PR TITLE
Fixed Thrusters Activation

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -768,6 +768,7 @@ MonoBehaviour:
   coreTempDecrease: 1
   thrustersCoreTemp: {fileID: 372956291}
   _coreTempCooledDown: 1
+  canPlayerUseThrusters: 0
   firstTimePlaying: 0
 --- !u!212 &391477478
 SpriteRenderer:
@@ -4828,6 +4829,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 55618495067fd4de5bb3f24cb4053128, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _playerScript: {fileID: 391477477}
+  _canThrustersScale: 0
 --- !u!95 &1935401785495550488
 Animator:
   serializedVersion: 3
@@ -5144,3 +5147,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 55618495067fd4de5bb3f24cb4053128, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _playerScript: {fileID: 391477477}
+  _canThrustersScale: 0

--- a/Assets/Scripts/ThrustersScale.cs
+++ b/Assets/Scripts/ThrustersScale.cs
@@ -4,20 +4,39 @@ using UnityEngine;
 
 public class ThrustersScale : MonoBehaviour
 {
+    [SerializeField] private PlayerScript _playerScript;
+    [SerializeField] private bool _canThrustersScale = false;
+
     void Start()
     {
         transform.localScale = new Vector3(0.1f, 0.63f, 0.5f);
+
+        _playerScript = GameObject.Find("Player").GetComponent<PlayerScript>();
+
+        if (_playerScript == null)
+        {
+            Debug.LogError("The PlayerScript is null.");
+        }
     }
 
     void Update()
     {
-        if (Input.GetKey(KeyCode.LeftShift))
+        if(_playerScript.canPlayerUseThrusters == true)
         {
-            transform.localScale = new Vector3(0.3f, 0.63f, 0.5f);
+            if (Input.GetKey(KeyCode.LeftShift))
+            {
+                transform.localScale = new Vector3(0.3f, 0.63f, 0.5f);
+            }
+            else
+            {
+                transform.localScale = new Vector3(0.1f, 0.63f, 0.5f);
+            }
         }
-        else
+
+        if (_playerScript.canPlayerUseThrusters == false)
         {
             transform.localScale = new Vector3(0.1f, 0.63f, 0.5f);
         }
+
     }
 }


### PR DESCRIPTION
Set it so that the thrusters are only activated after the countdown sequence, and only when the thruster core has cooled down.  If core temp exceeded, pressing Left-Shift will have no effect.